### PR TITLE
modified theano.function call to set allow_input_downcast=True for GPU compatibility

### DIFF
--- a/theanify/theanify.py
+++ b/theanify/theanify.py
@@ -54,7 +54,7 @@ class Theanifiable(object):
                     compiled = theano.function(
                         obj.args,
                         obj(*obj.args),
-                        updates=updates
+                        updates=updates,
                         allow_input_downcast=True
                     )
                     cache[name] = compiled

--- a/theanify/theanify.py
+++ b/theanify/theanify.py
@@ -55,6 +55,7 @@ class Theanifiable(object):
                         obj.args,
                         obj(*obj.args),
                         updates=updates
+                        allow_input_downcast=True
                     )
                     cache[name] = compiled
                     dirty = True


### PR DESCRIPTION
Inputs passed into theano functions are often double precision floats, but theano functions compiled for gpu expect single precision floats. Setting allow_input_downcast=True gives theano permission to downcast double-precision inputs appropriately. 
